### PR TITLE
Fix broken dataset_prepare link in the BeiT README

### DIFF
--- a/beit/semantic_segmentation/README.md
+++ b/beit/semantic_segmentation/README.md
@@ -17,7 +17,7 @@ cd apex
 pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 ```
 
-3. Follow the guide in [mmseg](https://github.com/open-mmlab/mmsegmentation/blob/master/docs/dataset_prepare.md) to prepare the ADE20k dataset.
+3. Follow the guide in [mmseg](https://github.com/open-mmlab/mmsegmentation/blob/master/docs/en/dataset_prepare.md#ade20k) to prepare the ADE20k dataset.
 
 
 ## Fine-tuning


### PR DESCRIPTION
This fixes the broken link to mmseg's guide (the `dataset_prepare.md` file) for preparing the ADE20k dataset in the BeiT Semantic Segmentation README file.